### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/mastfissh/safety_matrix/security/code-scanning/1](https://github.com/mastfissh/safety_matrix/security/code-scanning/1)

The best way to fix this issue is to explicitly specify a `permissions` block with the least privilege necessary at the workflow or job level.  
For this workflow, adding `permissions: contents: read` at the top level (just below the `name` entry and before `on:`) will ensure all jobs default to minimal read-only permissions to repository contents.  
This does not affect any workflow functionality, as the steps in question (checkout code, build, test, lint) only require read access to the repository source code.

Make the following change in `.github/workflows/node.js.yml`:
- Insert the following lines immediately after `name: Node.js CI` (line 4) and before `on:`:
  ```yaml
  permissions:
    contents: read
  ```

No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
